### PR TITLE
Add a policy for httpd

### DIFF
--- a/acm-httpd.yaml
+++ b/acm-httpd.yaml
@@ -59,6 +59,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
 metadata:
   name: namespace-httpd
+  namespace: namespace-httpd
   labels:
     app: httpd
 
@@ -77,7 +78,7 @@ apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
   name: namespace-httpd
-  Namespace: namespace-httpd                     
+  namespace: namespace-httpd                     
 spec:
   componentKinds:
   - group: apps.open-cluster-management.io
@@ -103,4 +104,4 @@ spec:
   clusterSelector:
     matchExpressions: []
     matchLabels:
-      environment: dev
+      name: jnp01

--- a/acm-httpd.yaml
+++ b/acm-httpd.yaml
@@ -104,4 +104,4 @@ spec:
   clusterSelector:
     matchExpressions: []
     matchLabels:
-      name: jnp01
+      environment: dev

--- a/scc-policy.yml
+++ b/scc-policy.yml
@@ -1,0 +1,85 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-elevate-scc
+  namespace: namespace-httpd
+  annotations:
+    policy.open-cluster-management.io/categories: PR.PT Protective Technology
+    policy.open-cluster-management.io/controls: PR.PT-3 Least Functionality
+    policy.open-cluster-management.io/standards: NIST-CSF
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: app-restricted-scc
+        spec:
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - namespace-httpd
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                allowedCapabilities: []
+                allowHostDirVolumePlugin: false
+                allowHostIPC: false
+                allowHostNetwork: false
+                allowHostPID: false
+                allowHostPorts: false
+                allowPrivilegedContainer: false
+                allowPrivilegeEscalation: true
+                apiVersion: security.openshift.io/v1
+                defaultAddCapabilities: []
+                fsGroup:
+                  type: RunAsAny
+                groups:
+                  - 'system:cluster-admins'
+                kind: SecurityContextConstraints
+                metadata:
+                  name: app-restricted-scc
+                  annotations:
+                    kubernetes.io/description: >-
+                      restricted denies access to all host features and requires
+                      pods to be run with a UID, and SELinux context that are
+                      allocated to the namespace.  This is the most restrictive
+                      SCC and it is used by default for authenticated users.
+                priority: 10
+                readOnlyRootFilesystem: false
+                requiredDropCapabilities:
+                  - MKNOD
+                runAsUser:
+                  type: RunAsAny
+                seLinuxContext:
+                  type: MustRunAs
+                supplementalGroups:
+                  type: RunAsAny
+                users:
+                  - 'system:serviceaccount:namespace-httpd:default'
+                volumes:
+                  - configMap
+                  - downwardAPI
+                  - emptyDir
+                  - persistentVolumeClaim
+                  - projected
+                  - secret
+          remediationAction: enforce
+          severity: high
+  remediationAction: enforce
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-app-scc
+  namespace: namespace-httpd
+placementRef:
+  name: httpd-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+- name: policy-elevate-scc
+  kind: Policy
+  apiGroup: policy.open-cluster-management.io


### PR DESCRIPTION
1. Fixed up some namespace references in acm-httpd.yaml
2. Added a policy to elevate containers running in `namespace-httpd`